### PR TITLE
Make storage functional tests work again

### DIFF
--- a/kubeadm-1.9.3/scripts/provision.sh
+++ b/kubeadm-1.9.3/scripts/provision.sh
@@ -15,6 +15,9 @@ systemctl disable firewalld NetworkManager || :
 # Enabling the firewall destroys the iptable rules
 yum -y remove NetworkManager firewalld
 
+# Required for iscsi demo to work.
+yum -y install iscsi-initiator-utils
+
 cat <<EOF >/etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes


### PR DESCRIPTION
iscsi utils weren't installed in the last 1.9.3 image.  This is making the PVC storage tests fail. 