### PR TITLE
Add optional nfs server to share host directories

### DIFF
--- a/cli/cli
+++ b/cli/cli
@@ -10,6 +10,7 @@ MEMORY=""
 CPU=""
 QEMU_ARGS=""
 BACKGROUND=""
+NFS_DATA=""
 
 COMMAND=$1
 shift
@@ -39,6 +40,7 @@ while true; do
     --osp-port ) OSP_PORT="$2"; shift 2 ;;
     --ssh-port ) SSH_PORT="$2"; shift 2 ;;
     --vnc-port ) VNC_PORT="$2"; shift 2 ;;
+    --nfs-data ) NFS_DATA="$2"; shift 2 ;;
     --registry-port ) REGISTRY_PORT="$2"; shift 2 ;;
     --registry-volume ) REGISTRY_VOLUME="$2"; shift 2 ;;
     -- ) shift; break ;;
@@ -125,6 +127,7 @@ fi
 DNSMASQ_CID=$(docker run -d ${PORTS} -e NUM_NODES=${NODES} --name ${PREFIX}dnsmasq --privileged ${BASE} /bin/bash -c /dnsmasq.sh)
 CONTAINERS=${DNSMASQ_CID}
 
+
 if [ "$COMMAND" == "provision" ] ; then
   VM_CID=$(docker run -d --privileged --net=container:${DNSMASQ_CID} --name ${PREFIX}node01 ${BASE} /bin/bash -c "/vm.sh ${MEMORY} ${CPU} ${QEMU_ARGS}")
   CONTAINERS="${CONTAINERS} ${VM_CID}"
@@ -146,8 +149,18 @@ else
   REGISTRY_CID=$(docker run -d --net=container:${DNSMASQ_CID} --name ${PREFIX}registry ${REGISTRY_VOLUME} registry:2)
   CONTAINERS="${CONTAINERS} ${REGISTRY_CID}"
 
+  if [ -n "${NFS_DATA}" ]; then
+    if [[ "$DIR" != /* ]]; then
+      NFS_DATA=${PWD}/${NFS_DATA}
+    fi
+    NFS_CID=$(docker run -d --privileged --net=container:${DNSMASQ_CID} --name ${PREFIX}nfs-ganesha -v ${NFS_DATA}:/data/nfs  janeczku/nfs-ganesha:latest)
+    CONTAINERS="${CONTAINERS} ${NFS_CID}"
+
+  # Let dnsmasq learn the nfs name
+  docker exec ${DNSMASQ_CID} /bin/bash -c 'echo 192.168.66.2 nfs >> /etc/hosts && kill -1 1'
+  fi
   # Let dnsmasq learn the registry dns name
-  docker exec ${DNSMASQ_CID} /bin/bash -c 'echo 192.168.66.2 registry > /etc/hosts && kill -1 1'
+  docker exec ${DNSMASQ_CID} /bin/bash -c 'echo 192.168.66.2 registry >> /etc/hosts && kill -1 1'
 
   # Start VMs      
   for i in $(seq 1 ${NODES}); do

--- a/kubeadm-1.9.3/README.md
+++ b/kubeadm-1.9.3/README.md
@@ -34,6 +34,26 @@ docker run --privileged --rm -v /var/run/docker.sock:/var/run/docker.sock rmohr/
 the initial provisioning of all vms is done. If an error occures during the
 initialization, the whole cluster is toren down.
 
+## Expsosing host data via NFS
+
+In order to share huge files (e.g. images which are only present on CI),
+sharing via NFS is possible. If a directory is added via `--nfs-data` when
+invoking the `run` subcommend, an additional nfs server is started and the data
+can be accessed from within the VMs. The DNS name of the nfs server is `nfs`
+inside the the vms.
+
+```bash
+docker run --privileged --rm -v /var/run/docker.sock:/var/run/docker.sock -v /nfs/data:/nfs/data rmohr/cli:latest run --nfs-data /nfs/data --nodes 2 --base rmohr/kubeadm-1.9.3
+```
+
+Within the vm it can be mounted via
+
+```bash
+sudo mount -t nfs4 nfs:/ /mnt/nfs
+```
+
+It is also very conveninent to share this data via PVs with pods this way.
+
 ## SSH into a running machine
 
 Running `cli` directly:
@@ -60,6 +80,7 @@ Running `cli` from withing docker:
 ```bash
 docker run --privileged -it -v /var/run/docker.sock:/var/run/docker.sock rmohr/cli:latest rm 
 ```
+
 
 ## Parallel execution
 


### PR DESCRIPTION
The added nfs server can be used to mount host directiries inside the
VMs, or via PVs with Pods.

Signed-off-by: Roman Mohr <rmohr@redhat.com>