### PR TITLE
Use newer CentOS images

### DIFF
--- a/centos7/Dockerfile
+++ b/centos7/Dockerfile
@@ -1,5 +1,5 @@
 FROM kubevirtci/base@sha256:840774a6731c52753dddafbcc69b51c25b891ec9622d4ee4ab73686b0c9dece1
 
-ENV CENTOS_URL http://cloud.centos.org/centos/7/vagrant/x86_64/images/CentOS-7-x86_64-Vagrant-1608_01.LibVirt.box
+ENV CENTOS_URL http://cloud.centos.org/centos/7/vagrant/x86_64/images/CentOS-7-x86_64-Vagrant-1802_01.Libvirt.box
 
 RUN /download_box.sh ${CENTOS_URL}


### PR DESCRIPTION
It will help to avoid problem with docker error

Error:
Error starting daemon: SELinux is not supported with the overlay2
graph driver on this kernel. Either boot into a newer kernel or
disable selinux in docker (--selinux-enabled=false)"

Signed-off-by: Lukianov Artyom <alukiano@redhat.com>